### PR TITLE
Add script for exporting subdomain pages as PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# website-to-pdf
+# Website to PDF
+
+This repository contains a Python script that downloads all subdomain pages of a given domain as PDFs and then merges them into a single file.
+
+## Requirements
+- Python 3
+- `requests`
+- `beautifulsoup4`
+- `pdfkit` (requires `wkhtmltopdf` installed)
+- `PyPDF2`
+
+## Usage
+Run the script with a domain name:
+
+```bash
+python domain_to_pdf.py example.com
+```
+
+The script will create a `pdfs` directory with individual PDFs and an `all_subdomains.pdf` file containing all merged pages.

--- a/domain_to_pdf.py
+++ b/domain_to_pdf.py
@@ -1,0 +1,65 @@
+import os
+import requests
+from urllib.parse import urlparse, urljoin
+from bs4 import BeautifulSoup
+import pdfkit
+from PyPDF2 import PdfWriter, PdfReader
+
+
+def find_subdomain_links(base_url):
+    """Fetch base_url and return set of full URLs to subdomains within the same domain."""
+    resp = requests.get(base_url)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, 'html.parser')
+    base_domain = urlparse(base_url).netloc
+    links = set()
+    for a in soup.find_all('a', href=True):
+        url = urljoin(base_url, a['href'])
+        netloc = urlparse(url).netloc
+        if netloc.endswith(base_domain) and netloc != base_domain:
+            links.add(url)
+    return links
+
+
+def save_page_as_pdf(url, output_dir):
+    """Save the given URL as a PDF in output_dir and return the path."""
+    os.makedirs(output_dir, exist_ok=True)
+    filename = urlparse(url).netloc.replace('.', '_') + '.pdf'
+    output_path = os.path.join(output_dir, filename)
+    pdfkit.from_url(url, output_path)
+    return output_path
+
+
+def merge_pdfs(pdf_paths, output_file):
+    """Merge PDFs from pdf_paths into output_file."""
+    writer = PdfWriter()
+    for pdf in pdf_paths:
+        reader = PdfReader(pdf)
+        for page in reader.pages:
+            writer.add_page(page)
+    with open(output_file, 'wb') as f:
+        writer.write(f)
+
+
+def main(domain):
+    if not domain.startswith('http'):  # Add scheme if missing
+        domain = 'http://' + domain
+    subdomains = find_subdomain_links(domain)
+    pdf_paths = []
+    for url in subdomains:
+        print(f"Saving {url}...")
+        pdf_path = save_page_as_pdf(url, 'pdfs')
+        pdf_paths.append(pdf_path)
+    if pdf_paths:
+        merge_pdfs(pdf_paths, 'all_subdomains.pdf')
+        print('Combined PDF saved as all_subdomains.pdf')
+    else:
+        print('No subdomains found.')
+
+
+if __name__ == '__main__':
+    import sys
+    if len(sys.argv) != 2:
+        print('Usage: python domain_to_pdf.py <domain>')
+        sys.exit(1)
+    main(sys.argv[1])


### PR DESCRIPTION
## Summary
- add `domain_to_pdf.py` script that scans subdomains, saves them as PDFs, and merges them
- update README with usage instructions and requirements

## Testing
- `python -m py_compile domain_to_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_6853c818d5648323a985b1a748eb5498