### PR TITLE
Improve internal link capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Website to PDF
 
-This repository contains a Python script that downloads all subdomain pages of a given domain as PDFs and then merges them into a single file.
+This repository contains a Python script that downloads all internal pages of a given domain as PDFs and then merges them into a single file.
 
 ## Requirements
 - Python 3
@@ -16,4 +16,4 @@ Run the script with a domain name:
 python domain_to_pdf.py example.com
 ```
 
-The script will create a `pdfs` directory with individual PDFs and an `all_subdomains.pdf` file containing all merged pages.
+The script will create a `pdfs` directory with individual PDFs and an `all_pages.pdf` file containing all merged pages.

--- a/domain_to_pdf.py
+++ b/domain_to_pdf.py
@@ -6,17 +6,16 @@ import pdfkit
 from PyPDF2 import PdfWriter, PdfReader
 
 
-def find_subdomain_links(base_url):
-    """Fetch base_url and return set of full URLs to subdomains within the same domain."""
+def find_internal_links(base_url):
+    """Fetch base_url and return set of full URLs within the same domain."""
     resp = requests.get(base_url)
     resp.raise_for_status()
     soup = BeautifulSoup(resp.text, 'html.parser')
-    base_domain = urlparse(base_url).netloc
+    base_netloc = urlparse(base_url).netloc
     links = set()
     for a in soup.find_all('a', href=True):
         url = urljoin(base_url, a['href'])
-        netloc = urlparse(url).netloc
-        if netloc.endswith(base_domain) and netloc != base_domain:
+        if urlparse(url).netloc == base_netloc:
             links.add(url)
     return links
 
@@ -24,7 +23,10 @@ def find_subdomain_links(base_url):
 def save_page_as_pdf(url, output_dir):
     """Save the given URL as a PDF in output_dir and return the path."""
     os.makedirs(output_dir, exist_ok=True)
-    filename = urlparse(url).netloc.replace('.', '_') + '.pdf'
+    parsed = urlparse(url)
+    safe_path = parsed.path.strip('/') or 'index'
+    safe_path = safe_path.replace('/', '_')
+    filename = f"{parsed.netloc.replace('.', '_')}_{safe_path}.pdf"
     output_path = os.path.join(output_dir, filename)
     pdfkit.from_url(url, output_path)
     return output_path
@@ -44,17 +46,17 @@ def merge_pdfs(pdf_paths, output_file):
 def main(domain):
     if not domain.startswith('http'):  # Add scheme if missing
         domain = 'http://' + domain
-    subdomains = find_subdomain_links(domain)
+    pages = find_internal_links(domain)
     pdf_paths = []
-    for url in subdomains:
+    for url in pages:
         print(f"Saving {url}...")
         pdf_path = save_page_as_pdf(url, 'pdfs')
         pdf_paths.append(pdf_path)
     if pdf_paths:
-        merge_pdfs(pdf_paths, 'all_subdomains.pdf')
-        print('Combined PDF saved as all_subdomains.pdf')
+        merge_pdfs(pdf_paths, 'all_pages.pdf')
+        print('Combined PDF saved as all_pages.pdf')
     else:
-        print('No subdomains found.')
+        print('No internal pages found.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- fetch and merge internal pages instead of subdomains
- name merged pdf `all_pages.pdf`
- include page path when saving PDFs

## Testing
- `python -m py_compile domain_to_pdf.py`
- `pip install requests bs4 PyPDF2 pdfkit tldextract` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6853cc46a59c8323803ed80c15b14605