### PR TITLE
Switch to internal link scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Website to PDF
 
-This repository contains a Python script that downloads all subdomain pages of a given domain as PDFs and then merges them into a single file.
+This repository contains a Python script that downloads the internal pages of a given domain as PDFs and then merges them into a single file.
 
 ## Requirements
 - Python 3
@@ -16,4 +16,4 @@ Run the script with a domain name:
 python domain_to_pdf.py example.com
 ```
 
-The script will create a `pdfs` directory with individual PDFs and an `all_subdomains.pdf` file containing all merged pages.
+The script will create a `pdfs` directory with individual PDFs and an `internal_pages.pdf` file containing all merged pages.

--- a/domain_to_pdf.py
+++ b/domain_to_pdf.py
@@ -1,39 +1,39 @@
 import os
-import requests
 from urllib.parse import urlparse, urljoin
+
+import requests
 from bs4 import BeautifulSoup
 import pdfkit
 from PyPDF2 import PdfWriter, PdfReader
 
 
-def _get_root_domain(netloc: str) -> str:
-    """Return the registrable part of a netloc (e.g. example.com)."""
-    parts = netloc.split('.')
-    if len(parts) >= 2:
-        return '.'.join(parts[-2:])
-    return netloc
-
-
-def find_subdomain_links(base_url):
-    """Fetch base_url and return set of full URLs to subdomains within the same domain."""
+def find_internal_links(base_url: str) -> set[str]:
+    """Return a set of full URLs that are internal to ``base_url``."""
     resp = requests.get(base_url)
     resp.raise_for_status()
-    soup = BeautifulSoup(resp.text, 'html.parser')
+    soup = BeautifulSoup(resp.text, "html.parser")
+
     base_netloc = urlparse(base_url).netloc
-    base_root = _get_root_domain(base_netloc)
-    links = set()
-    for a in soup.find_all('a', href=True):
-        url = urljoin(base_url, a['href'])
-        netloc = urlparse(url).netloc
-        if netloc and netloc != base_netloc and _get_root_domain(netloc) == base_root:
+    links: set[str] = set()
+
+    for a in soup.find_all("a", href=True):
+        url = urljoin(base_url, a["href"])
+        if urlparse(url).netloc == base_netloc:
             links.add(url)
+
     return links
 
 
-def save_page_as_pdf(url, output_dir):
-    """Save the given URL as a PDF in output_dir and return the path."""
+def save_page_as_pdf(url: str, output_dir: str) -> str:
+    """Save ``url`` as a PDF in ``output_dir`` and return the created path."""
     os.makedirs(output_dir, exist_ok=True)
-    filename = urlparse(url).netloc.replace('.', '_') + '.pdf'
+
+    parsed = urlparse(url)
+    path = parsed.path.strip("/")
+    if not path:
+        path = "index"
+    filename = f"{parsed.netloc.replace('.', '_')}_{path.replace('/', '_')}.pdf"
+
     output_path = os.path.join(output_dir, filename)
     pdfkit.from_url(url, output_path)
     return output_path
@@ -51,19 +51,22 @@ def merge_pdfs(pdf_paths, output_file):
 
 
 def main(domain):
-    if not domain.startswith('http'):  # Add scheme if missing
-        domain = 'http://' + domain
-    subdomains = find_subdomain_links(domain)
-    pdf_paths = []
-    for url in subdomains:
+    if not domain.startswith("http"):  # Add scheme if missing
+        domain = "http://" + domain
+
+    pages = find_internal_links(domain)
+    pdf_paths: list[str] = []
+
+    for url in pages:
         print(f"Saving {url}...")
-        pdf_path = save_page_as_pdf(url, 'pdfs')
+        pdf_path = save_page_as_pdf(url, "pdfs")
         pdf_paths.append(pdf_path)
+
     if pdf_paths:
-        merge_pdfs(pdf_paths, 'all_subdomains.pdf')
-        print('Combined PDF saved as all_subdomains.pdf')
+        merge_pdfs(pdf_paths, "internal_pages.pdf")
+        print("Combined PDF saved as internal_pages.pdf")
     else:
-        print('No subdomains found.')
+        print("No internal links found.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- scrape and merge internal page links instead of subdomains
- clean up save filename logic
- update README

## Testing
- `python -m py_compile domain_to_pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_6853cf87cd7083239388c2a374e94ab2