### PR TITLE
Interactive domain input

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ This repository contains a Python script that downloads the internal pages of a 
 - `PyPDF2`
 
 ## Usage
-Run the script with a domain name:
+
+Run the script and provide a domain when prompted:
 
 ```bash
-python domain_to_pdf.py example.com
+python domain_to_pdf.py
 ```
 
 The script will create a `pdfs` directory with individual PDFs and an `internal_pages.pdf` file containing all merged pages.

--- a/domain_to_pdf.py
+++ b/domain_to_pdf.py
@@ -1,26 +1,8 @@
 import os
 import sys
-import subprocess
 from urllib.parse import urlparse, urljoin
 
 
-def _ensure_colab_dependencies() -> None:
-    """Install required packages when running on Google Colab."""
-    try:
-        import google.colab  # type: ignore
-    except ImportError:  # Not running on Colab
-        return
-
-    # Install wkhtmltopdf via apt and required python packages
-    subprocess.run(["apt-get", "update"], check=False)
-    subprocess.run(["apt-get", "install", "-y", "wkhtmltopdf"], check=False)
-    subprocess.run(
-        [sys.executable, "-m", "pip", "install", "pdfkit", "requests", "beautifulsoup4", "PyPDF2"],
-        check=False,
-    )
-
-
-_ensure_colab_dependencies()
 
 import requests
 from bs4 import BeautifulSoup
@@ -96,8 +78,8 @@ def main(domain):
 
 
 if __name__ == '__main__':
-    import sys
-    if len(sys.argv) != 2:
-        print('Usage: python domain_to_pdf.py <domain>')
+    domain = input('Enter domain: ').strip()
+    if not domain:
+        print('No domain provided.')
         sys.exit(1)
-    main(sys.argv[1])
+    main(domain)


### PR DESCRIPTION
## Summary
- remove Google Colab installation helper
- prompt for a domain when running script
- update documentation for new usage

## Testing
- `python -m py_compile domain_to_pdf.py`
- `python domain_to_pdf.py <<'EOF'
example.com
EOF` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6853d1a1e2dc8323b2090ae74f0e2d81