### PR TITLE
Validate internal links before saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ python domain_to_pdf.py
 ```
 
 The script will create a `pdfs` directory with individual PDFs and an `internal_pages.pdf` file containing all merged pages.
+Internal links are validated before processing to avoid invalid pages.


### PR DESCRIPTION
## Summary
- add a helper to verify URLs using HEAD/GET
- only include internal links that are reachable
- check the base domain is reachable before scraping
- document the new validation behaviour

## Testing
- `python -m py_compile domain_to_pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_6853d36141e8832389523f6122e0e729