### PR TITLE
Add page text check for 404 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ python domain_to_pdf.py
 ```
 
 The script will create a `pdfs` directory with individual PDFs and an `internal_pages.pdf` file containing all merged pages.
-Internal links are validated before processing to avoid invalid pages.
+Internal links are validated before processing to avoid invalid pages. Any page that contains the text "Error 404" is skipped.

--- a/domain_to_pdf.py
+++ b/domain_to_pdf.py
@@ -16,16 +16,23 @@ _PDFKIT_CONFIG = (
 
 
 def _url_is_valid(url: str) -> bool:
-    """Return ``True`` if ``url`` resolves successfully (status < 400)."""
+    """Return ``True`` if ``url`` resolves successfully and is not a 404 page."""
+
     try:
-        resp = requests.head(url, allow_redirects=True, timeout=5)
-        if resp.status_code < 400:
-            return True
+        head_resp = requests.head(url, allow_redirects=True, timeout=5)
+        if head_resp.status_code >= 400:
+            return False
     except requests.RequestException:
+        # Some servers may not handle HEAD requests
         pass
+
     try:
-        with requests.get(url, allow_redirects=True, stream=True, timeout=5) as resp:
-            return resp.status_code < 400
+        resp = requests.get(url, allow_redirects=True, timeout=5)
+        if resp.status_code >= 400:
+            return False
+        if "error 404" in resp.text.lower():
+            return False
+        return True
     except requests.RequestException:
         return False
 


### PR DESCRIPTION
## Summary
- detect pages that show `Error 404` when validating URLs
- document new behaviour in README

## Testing
- `pytest -q`
- `python -m py_compile domain_to_pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_6853d86a42c08323a212046e9eab23c2