### PR TITLE
Add file logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ python domain_to_pdf.py
 The script will create a `pdfs` directory with individual PDFs and an `internal_pages.pdf` file containing all merged pages.
 Internal links are validated before processing to avoid invalid pages. Any page that contains the text "Error 404" is skipped.
 
-Progress messages are printed to the console so you can follow the stages of the process, including validation, link discovery, page saving and PDF merging.
+Progress messages are printed to the console so you can follow the stages of the process, including validation, link discovery, page saving and PDF merging. The same information is written to `website_to_pdf.log` for real-time logging.

--- a/domain_to_pdf.py
+++ b/domain_to_pdf.py
@@ -9,7 +9,16 @@ import shutil
 import pdfkit
 from PyPDF2 import PdfWriter, PdfReader
 
-logging.basicConfig(level=logging.INFO, format="%(message)s")
+LOG_FILE = "website_to_pdf.log"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(message)s",
+    handlers=[
+        logging.StreamHandler(sys.stdout),
+        logging.FileHandler(LOG_FILE, mode="w", encoding="utf-8"),
+    ],
+)
 
 
 WKHTMLTOPDF_PATH = shutil.which("wkhtmltopdf")


### PR DESCRIPTION
## Summary
- log to both stdout and `website_to_pdf.log`
- document the location of log file in README

## Testing
- `python -m py_compile domain_to_pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_6853dd46225083238d38cf0ea28ec3db