### PR TITLE
Add caching for checked internal links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ python domain_to_pdf.py
 ```
 
 The script will create a `pdfs` directory with individual PDFs and an `internal_pages.pdf` file containing all merged pages.
-Internal links are validated as they are discovered so invalid pages are skipped immediately. Links discovered within internal pages are followed as well, ensuring every reachable page is processed. Any page that contains the text "Error 404" is skipped.
+Internal links are validated as they are discovered so invalid pages are skipped immediately. Links discovered within internal pages are followed as well, ensuring every reachable page is processed. Any page that contains the text "Error 404" is skipped. All checked internal links are remembered so duplicates are not validated again.
 
 Progress is displayed in the console so you can follow link validation, page saving and PDF merging without flooding your terminal. A simple progress bar shows the download of each page.

--- a/domain_to_pdf.py
+++ b/domain_to_pdf.py
@@ -82,6 +82,7 @@ def find_internal_links(base_url: str) -> tuple[set[str], int, int]:
     base_netloc = urlparse(base_url).netloc
 
     links: set[str] = {base_url}
+    checked_links: set[str] = {base_url}
     invalid_count = 0
     total_internal = 0
 
@@ -110,20 +111,22 @@ def find_internal_links(base_url: str) -> tuple[set[str], int, int]:
             if urlparse(url).netloc != base_netloc:
                 continue
             total_internal += 1
-            if url not in links:
-                if _url_is_valid(url):
-                    links.add(url)
-                    to_visit.add(url)
-                    status = f"Valid: {url}"
-                else:
-                    invalid_count += 1
-                    status = f"Invalid: {url}"
-                _print_progress(
-                    "Checking links",
-                    idx,
-                    total,
-                    f"(total: {total_internal}, valid: {len(links)}, invalid: {invalid_count}) {status}",
-                )
+            if url in checked_links:
+                continue
+            checked_links.add(url)
+            if _url_is_valid(url):
+                links.add(url)
+                to_visit.add(url)
+                status = f"Valid: {url}"
+            else:
+                invalid_count += 1
+                status = f"Invalid: {url}"
+            _print_progress(
+                "Checking links",
+                idx,
+                total,
+                f"(total: {total_internal}, valid: {len(links)}, invalid: {invalid_count}) {status}",
+            )
         if not anchors:
             _print_progress(
                 "Checking links",


### PR DESCRIPTION
## Summary
- keep track of every checked internal link
- skip URL validation for links that have already been processed
- update README to mention duplicate check caching

## Testing
- `python -m py_compile domain_to_pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_6853ead6968883238056dcb8c7c52746