### PR TITLE
Add multi-domain PDF export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ This repository contains a Python script that downloads **all** internal pages o
 
 ## Usage
 
-Run the script and provide a domain when prompted:
+Run the script and provide one or more domains when prompted or via command line:
 
 ```bash
-python domain_to_pdf.py
+python domain_to_pdf.py example.com example.org
 ```
 
-The script will create a `pdfs` directory with individual PDFs and an `internal_pages.pdf` file containing all merged pages.
+The script will create a `pdfs/<domain>` directory for each domain with individual PDFs. A final merged PDF named `<domain>.pdf` is placed in the same directory.
 Internal links are validated as they are discovered so invalid pages are skipped immediately. Links discovered within internal pages are followed as well, ensuring every reachable page is processed. Any page that contains the text "Error 404" is skipped. All checked internal links are remembered so duplicates are not validated again.
 
 Progress is displayed in the console so you can follow link validation, page saving and PDF merging without flooding your terminal. A simple progress bar shows the download of each page.


### PR DESCRIPTION
## Summary
- allow processing multiple domains at once
- store PDFs in domain-specific folders
- name merged output after the domain
- document new usage

## Testing
- `python -m py_compile domain_to_pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_6853ec55df208323b5fa6ea9de46d7fe