### PR TITLE
Fix Jupyter arg handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,16 @@ The script will create a `pdfs/<domain>` directory for each domain with individu
 Internal links are validated as they are discovered so invalid pages are skipped immediately. Links discovered within internal pages are followed as well, ensuring every reachable page is processed. Any page that contains the text "Error 404" is skipped. All checked internal links are remembered so duplicates are not validated again.
 
 Progress is displayed in the console so you can follow link validation, page saving and PDF merging without flooding your terminal. A simple progress bar shows the download of each page.
+
+### Running in Jupyter or Google Colab
+
+When running the script inside a notebook environment (e.g. Google Colab), use
+the `!python` command. The script automatically removes arguments inserted by
+IPython so you can simply run:
+
+```bash
+!python domain_to_pdf.py
+```
+
+If you do not pass domains on the command line, the script will prompt you to
+enter them interactively.

--- a/domain_to_pdf.py
+++ b/domain_to_pdf.py
@@ -10,6 +10,19 @@ import shutil
 import pdfkit
 from PyPDF2 import PdfWriter, PdfReader
 
+# Remove arguments injected by IPython (e.g. "-f <connection file>") so that
+# interactive input works when running inside notebooks like Google Colab.
+def _remove_ipykernel_args() -> None:
+    if "-f" in sys.argv:
+        f_index = sys.argv.index("-f")
+        # Remove '-f' and the path that follows it if present
+        if f_index < len(sys.argv) - 1:
+            del sys.argv[f_index : f_index + 2]
+        else:
+            del sys.argv[f_index]
+
+_remove_ipykernel_args()
+
 # Simple colored output helpers
 GREEN = "\033[92m"
 RED = "\033[91m"


### PR DESCRIPTION
## Summary
- strip IPython `-f` args from `sys.argv` to allow interactive input
- document running the script in Jupyter/Colab

## Testing
- `python -m py_compile domain_to_pdf.py`
- `python domain_to_pdf.py example.com --help` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6853ef044d9483238ec4426d439323e2